### PR TITLE
ListTableList block 中StandardTable组件无法禁用分页的bug

### DIFF
--- a/ListTableList/src/components/StandardTable/index.tsx
+++ b/ListTableList/src/components/StandardTable/index.tsx
@@ -105,7 +105,7 @@ class StandardTable extends Component<StandardTableProps<TableListItem>, Standar
     const { data, rowKey, ...rest } = this.props;
     const { list = [], pagination = false } = data || {};
 
-    const paginationProps = {
+    const paginationProps = pagination===false?false:{
       showSizeChanger: true,
       showQuickJumper: true,
       ...pagination,

--- a/ListTableList/src/components/StandardTable/index.tsx
+++ b/ListTableList/src/components/StandardTable/index.tsx
@@ -105,11 +105,11 @@ class StandardTable extends Component<StandardTableProps<TableListItem>, Standar
     const { data, rowKey, ...rest } = this.props;
     const { list = [], pagination = false } = data || {};
 
-    const paginationProps = pagination===false?false:{
+    const paginationProps = pagination ? {
       showSizeChanger: true,
       showQuickJumper: true,
       ...pagination,
-    };
+    } : false;
 
     const rowSelection: TableRowSelection<TableListItem> = {
       selectedRowKeys,


### PR DESCRIPTION
修复StandardTable组件无法禁用分页，即使设置了pagination=false也无法禁用分页的bug