### PR TITLE
FIX 列表项目key值重复以及 高级表单取消无效的bug

### DIFF
--- a/FormAdvancedForm/src/components/TableForm.tsx
+++ b/FormAdvancedForm/src/components/TableForm.tsx
@@ -247,21 +247,24 @@ class TableForm extends PureComponent<TableFormProps, TableFormState> {
     e.preventDefault();
     const { data = [] } = this.state;
     const newData = [...data];
-    newData.map(item => {
+    // 编辑前的原始数据
+    let cacheOriginData = [];
+    cacheOriginData = newData.map(item => {
       if (item.key === key) {
         if (this.cacheOriginData[key]) {
-          delete this.cacheOriginData[key];
-          return {
+          const originItem = {
             ...item,
             ...this.cacheOriginData[key],
             editable: false,
           };
+          delete this.cacheOriginData[key];
+          return originItem;
         }
       }
       return item;
     });
 
-    this.setState({ data: newData });
+    this.setState({ data: cacheOriginData });
     this.clickedCancel = false;
   }
 

--- a/ListSearchProjects/src/index.tsx
+++ b/ListSearchProjects/src/index.tsx
@@ -66,9 +66,9 @@ class PAGE_NAME_UPPER_CAMEL_CASE extends Component<PAGE_NAME_UPPER_CAMEL_CASEPro
                 <span>{moment(item.updatedAt).fromNow()}</span>
                 <div className={styles.avatarList}>
                   <AvatarList size="small">
-                    {item.members.map(member => (
+                    {item.members.map((member, index) => (
                       <AvatarList.Item
-                        key={`${item.id}-avatar`}
+                        key={`${item.id}-${index}`}
                         src={member.avatar}
                         tips={member.name}
                       />


### PR DESCRIPTION
FIX 列表项目key值重复以及 高级表单取消无效的bug

1. 下载区块搜索列表项目 key值报错
![image](https://user-images.githubusercontent.com/23131032/62190470-fef4ad80-b3a3-11e9-8c74-8cdca29f4b6d.png)

2. 高级表单成员管理 点击取消交互逻辑没有发生变化

![vue inputnumber](https://user-images.githubusercontent.com/23131032/62191322-e1284800-b3a5-11e9-8bcd-44842ec0cefb.gif)

问题出现的原因：
1. map并不会修改原有的数组，会返回新的数组。
2. this.cacheOriginData[key]原始数据应该回复后，才能删除，否则为undefined，回复不了原来的数据了。
![image](https://user-images.githubusercontent.com/23131032/62191504-29e00100-b3a6-11e9-9875-d79337e0fd64.png)

修改后的结果：
![vue inputnumber1](https://user-images.githubusercontent.com/23131032/62191358-eb4a4680-b3a5-11e9-94fa-3abeb9055cf4.gif)


