### PR TITLE
解决高级表单底部的提交按钮栏宽度错误的bug

### DIFF
--- a/FormAdvancedForm/src/index.tsx
+++ b/FormAdvancedForm/src/index.tsx
@@ -75,6 +75,7 @@ class PAGE_NAME_UPPER_CAMEL_CASE extends Component<PAGE_NAME_UPPER_CAMEL_CASEPro
 
   componentDidMount() {
     window.addEventListener('resize', this.resizeFooterToolbar, { passive: true });
+    this.resizeFooterToolbar();
   }
 
   componentWillUnmount() {


### PR DESCRIPTION
解决表单页-高级表单底部的提交按钮栏布局默认宽度为100%的bug