### PR TITLE
Fix: TableProps ts warning

### DIFF
--- a/ListTableList/src/components/StandardTable/index.tsx
+++ b/ListTableList/src/components/StandardTable/index.tsx
@@ -7,7 +7,11 @@ import styles from './index.less';
 
 type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
 
-export interface StandardTableProps<T> extends Omit<TableProps<T>, 'columns'> {
+export interface StandardTableProps<T>
+  extends Omit<
+    TableProps<T>,
+    'columns' | 'store' | 'checkboxPropsCache' | 'setCheckboxPropsCache'
+  > {
   columns: StandardTableColumnProps[];
   data: {
     list: TableListItem[];


### PR DESCRIPTION
antd更新后原Table的props继承了withStore，造成了使用自定义Table组件的地方大量报错