### PR TITLE
fileList={[]} => showUploadList={false}

### DIFF
--- a/AccountSettings/src/components/base.tsx
+++ b/AccountSettings/src/components/base.tsx
@@ -21,7 +21,7 @@ const AvatarView = ({ avatar }: { avatar: string }) => (
     <div className={styles.avatar}>
       <img src={avatar} alt="avatar" />
     </div>
-    <Upload fileList={[]}>
+    <Upload showUploadList={false}>
       <div className={styles.button_view}>
         <Button icon="upload">
           <FormattedMessage id="BLOCK_NAME.basic.change-avatar" defaultMessage="Change avatar" />


### PR DESCRIPTION
强制将fileList设置成[]，将会造成在Upload的onChange中发生错误，导致无法跟踪到info.file.statue="done"的情况。
虽然这里只是一个示例，但要避免给使用者带来困扰。